### PR TITLE
Added Support for granting capabilites to multiple users at once

### DIFF
--- a/docusign/package-lock.json
+++ b/docusign/package-lock.json
@@ -17,6 +17,7 @@
         "@web3-storage/w3cli": "^7.12.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "jspdf": "^3.0.1",
         "lucide-react": "^0.513.0",
         "next": "15.3.3",
         "pdfjs-dist": "^3.4.120",
@@ -62,6 +63,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.27.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
+      "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -2669,6 +2679,13 @@
         "undici-types": "~6.19.2"
       }
     },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/react": {
       "version": "19.1.6",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.6.tgz",
@@ -2694,6 +2711,13 @@
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.2.tgz",
       "integrity": "sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==",
       "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/wrap-ansi": {
       "version": "3.0.0",
@@ -3887,6 +3911,18 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/atob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "license": "(MIT OR Apache-2.0)",
+      "bin": {
+        "atob": "bin/atob.js"
+      },
+      "engines": {
+        "node": ">= 4.5.0"
+      }
+    },
     "node_modules/atomically": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/atomically/-/atomically-2.0.3.tgz",
@@ -3937,6 +3973,16 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
+    },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -4141,6 +4187,18 @@
       "integrity": "sha512-+12sHB+Br8HIh6VAMVEG5r3UXCyESIgDW7kzk3BjIXa43DVqVwL7GC5TW3jeh+72dtcH99pPVpw0X8i0jt+/kw==",
       "license": "ISC"
     },
+    "node_modules/btoa": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
+      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==",
+      "license": "(MIT OR Apache-2.0)",
+      "bin": {
+        "btoa": "bin/btoa.js"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/buffer": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
@@ -4282,6 +4340,26 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canvg": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/carstream": {
       "version": "2.3.0",
@@ -4569,6 +4647,18 @@
       "license": "ISC",
       "optional": true
     },
+    "node_modules/core-js": {
+      "version": "3.43.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.43.0.tgz",
+      "integrity": "sha512-N6wEbTTZSYOY2rYAn85CuvWWkCK6QweMn7/4Nr3w+gDBeBhk/x4EJeY6FPo4QzDoJZxVTv8U7CMvgWk6pOHHqA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -4608,6 +4698,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/csstype": {
@@ -4837,6 +4937,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
+      "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optional": true,
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/dot-prop": {
@@ -5712,6 +5822,12 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
+    },
     "node_modules/figures": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -6304,6 +6420,20 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/https-proxy-agent": {
@@ -7210,6 +7340,24 @@
       },
       "bin": {
         "json5": "lib/cli.js"
+      }
+    },
+    "node_modules/jspdf": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-3.0.1.tgz",
+      "integrity": "sha512-qaGIxqxetdoNnFQQXxTKUD9/Z7AloLaw94fFsOiJMxbfYdBbrBuhWmbzI8TVjrw7s3jBY1PFHofBKMV/wZPapg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.7",
+        "atob": "^2.1.2",
+        "btoa": "^1.2.1",
+        "fflate": "^0.8.1"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.11",
+        "core-js": "^3.6.0",
+        "dompurify": "^3.2.4",
+        "html2canvas": "^1.0.0-rc.5"
       }
     },
     "node_modules/jsx-ast-utils": {
@@ -8535,6 +8683,13 @@
         "simple-concat": "^1.0.0"
       }
     },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -8776,6 +8931,16 @@
       "integrity": "sha512-5y72gAXPzIBsAMHcpxZP8eMDuDT98qMP1BqSDHRbHkJJXEgWIN1lA47LxUqzsK6jknOJtgfkQr9v+7qMlFDm6g==",
       "license": "(Apache-2.0 AND MIT)"
     },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
+    },
     "node_modules/rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -8888,6 +9053,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
@@ -9051,6 +9223,16 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
       }
     },
     "node_modules/rimraf": {
@@ -9584,6 +9766,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
     "node_modules/stdin-discarder": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.1.0.tgz",
@@ -9902,6 +10094,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/sync-multihash-sha2": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/sync-multihash-sha2/-/sync-multihash-sha2-1.0.0.tgz",
@@ -9954,6 +10156,16 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/tinyglobby": {
@@ -10339,6 +10551,16 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
+      }
     },
     "node_modules/varint": {
       "version": "6.0.0",

--- a/docusign/package.json
+++ b/docusign/package.json
@@ -18,6 +18,7 @@
     "@web3-storage/w3cli": "^7.12.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "jspdf": "^3.0.1",
     "lucide-react": "^0.513.0",
     "next": "15.3.3",
     "pdfjs-dist": "^3.4.120",

--- a/docusign/src/app/page.tsx
+++ b/docusign/src/app/page.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import FileUploader from "@/components/FileUploader";
 import UploadResult from "@/components/UploadResult";
-
+import { RoleBasedAccessComponent } from "@/components/RolesComponent";
 export default function Home() {
   const [uploadResult, setUploadResult] = useState(null);
   const [error, setError] = useState<string | null>(null);
@@ -24,6 +24,8 @@ export default function Home() {
         }}
       />
       {uploadResult && <UploadResult result={uploadResult} />}
+       {/*Assigning Role Based Acess */}
+       {uploadResult !== null &&  <RoleBasedAccessComponent result={uploadResult} />}
     </main>
   );
 }

--- a/docusign/src/components/FileUploader.tsx
+++ b/docusign/src/components/FileUploader.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useCallback } from "react";
+import { useState, useRef, useCallback, useEffect } from "react";
 import { Upload, File, X, Loader2 } from "lucide-react";
 
 export default function FileUploader({ onUploadSuccess, onUploadError }: any) {
@@ -9,6 +9,7 @@ export default function FileUploader({ onUploadSuccess, onUploadError }: any) {
   const [isDragOver, setIsDragOver] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [isUploaded, setIsUploaded] = useState(false);
+  const [fileCid, setFileCid]=useState<string>("");
 
   const handleDragOver = useCallback((e: React.DragEvent) => {
     e.preventDefault();
@@ -19,6 +20,10 @@ export default function FileUploader({ onUploadSuccess, onUploadError }: any) {
     e.preventDefault();
     setIsDragOver(false);
   }, []);
+
+useEffect(()=>{
+  
+},[isUploaded, fileCid])
 
   const handleDrop = useCallback(
     (e: React.DragEvent) => {
@@ -83,6 +88,7 @@ export default function FileUploader({ onUploadSuccess, onUploadError }: any) {
 
       if (result.success) {
         onUploadSuccess(result.data);
+        setFileCid(result.data.cid)
         setIsUploaded(true);
       } else {
         onUploadError(result.error);
@@ -173,7 +179,7 @@ export default function FileUploader({ onUploadSuccess, onUploadError }: any) {
             </div>
           )}
         </div>
-
+      
         {/* Upload Button */}
         <button
           type="button"
@@ -200,6 +206,8 @@ export default function FileUploader({ onUploadSuccess, onUploadError }: any) {
             </>
           )}
         </button>
+
+       
       </div>
     </div>
   );

--- a/docusign/src/components/RolesComponent/DelegationSuccessComp/index.tsx
+++ b/docusign/src/components/RolesComponent/DelegationSuccessComp/index.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+
+interface Props {
+  cid: string;
+}
+
+export const DelegationSuccessMessage = ({ cid }:Props) => {
+  return (
+    <div className="max-w-xl mx-auto mt-10 p-6 bg-green-50 dark:bg-green-900 text-green-800 dark:text-green-100 border border-green-300 dark:border-green-700 rounded-2xl shadow-lg">
+      <h2 className="text-lg font-semibold mb-4"> Delegation Successful!</h2>
+      <p className="mb-2">
+        You’ve successfully delegated access for file:
+      </p>
+      <p className="break-words text-indigo-700 dark:text-indigo-300 font-mono text-sm">
+        {cid}
+      </p>
+    </div>
+  );
+};

--- a/docusign/src/components/RolesComponent/index.tsx
+++ b/docusign/src/components/RolesComponent/index.tsx
@@ -1,0 +1,245 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import React, { useState } from "react";
+import { Signer } from "@/types/types";
+import { baseCapabilities } from "@/utils/fileHelpers";
+import * as Delegation from "@ucanto/core/delegation";
+import { DelegationSuccessMessage } from "./DelegationSuccessComp";
+import jsPDF from "jspdf";
+
+export const RoleBasedAccessComponent = ({ result }: { result: any }) => {
+  const [numSigners, setNumSigners] = useState(1);
+  const [signers, setSigners] = useState<Signer[]>([
+    { did: "", capabilities: [] as string[], deadline: "" },
+  ]);
+  const [delegated, setDelegated] = useState<boolean>(false);
+
+  const handleSignerCountChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const count = parseInt(e.target.value);
+    setNumSigners(count);
+    const updatedSigners = Array.from(
+      { length: count },
+      (_, i) => signers[i] || { did: "", capabilities: [], deadline: "" }
+    );
+    setSigners(updatedSigners);
+  };
+
+  const updateSignerField = (
+    index: number,
+    field: "did" | "capabilities" | "deadline",
+    value: string | string[]
+  ) => {
+    const updated = [...signers];
+    if (field === "capabilities" && Array.isArray(value)) {
+      updated[index].capabilities = value;
+    } else if (field !== "capabilities" && typeof value === "string") {
+      updated[index][field] = value;
+    }
+    setSigners(updated);
+  };
+
+  const toggleCapability = (index: number, capability: string) => {
+    const updated = [...signers];
+    const current = updated[index].capabilities;
+    if (current.includes(capability)) {
+      updated[index].capabilities = current.filter((c) => c !== capability);
+    } else {
+      updated[index].capabilities = [...current, capability];
+    }
+    setSigners(updated);
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      const formattedSigners: Signer[] = signers.map((signer) => ({
+        did: signer.did,
+        capabilities: signer.capabilities,
+        deadline: Math.floor(
+          new Date(signer.deadline).getTime() / 1000
+        ).toString(),
+      }));
+
+      const payload = {
+        cid: result.cid,
+        numSigners,
+        signers: formattedSigners,
+      };
+      const res = await fetch("/api/Delegate", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(payload),
+      });
+      const response = await res.json();
+      const { delegationResult } = response.data;
+
+      //Storing the Generated Delegation Directly in the localStorage of the user so that they can be shared to the respective agent to be used by them.
+      const savedDelegations = delegationResult.map(
+        ({
+          receipientDid,
+          delegationBase64ToSendToFrontend,
+        }: {
+          receipientDid: string;
+          delegationBase64ToSendToFrontend: string;
+        }) => {
+          const delegationBuffer = Uint8Array.from(
+            atob(delegationBase64ToSendToFrontend),
+            (c) => c.charCodeAt(0)
+          );
+          Delegation.extract(delegationBuffer).then((extractedDelegation) => {
+            console.log(
+              "Delegation for",
+              receipientDid,
+              ":",
+              extractedDelegation.ok
+            );
+          });
+          return {
+            recipientDid: receipientDid,
+            delegation: delegationBase64ToSendToFrontend,
+          };
+        }
+      );
+      // Saving to localStorage using fileCid as key
+      const storageKey = `delegations:${result.cid}`;
+      localStorage.setItem(storageKey, JSON.stringify(savedDelegations));
+      setDelegated(true);
+      const doc = new jsPDF();
+      const readableText = JSON.stringify(savedDelegations, null, 2);
+      const lines = doc.splitTextToSize(readableText, 180);
+      doc.text(lines, 10, 10);
+      const pdfBlob = doc.output("blob");
+      const delegationFileObject = new File(
+        [pdfBlob],
+        `delegations-${result.cid}.pdf`,
+        {
+          type: "application/pdf",
+        }
+      );
+      const formData = new FormData();
+      formData.append("file", delegationFileObject);
+      const storeProofresponse = await fetch("/api/upload", {
+        method: "POST",
+        body: formData,
+      });
+      const uploadResult = await storeProofresponse.json();
+    } catch (err) {
+      console.error("Failed to send data to backend:", err);
+    }
+  };
+
+  if (delegated) {
+    return <DelegationSuccessMessage cid={result.cid} />;
+  }
+
+  return (
+    <div
+      className={`${
+        numSigners > 1 ? "max-w-4xl" : "max-w-2xl"
+      } mx-auto mt-10 p-6 bg-white dark:bg-gray-900 shadow-lg rounded-2xl border border-gray-200 dark:border-gray-700`}
+    >
+      <h2 className="text-md font-semibold text-gray-800 dark:text-white mb-6">
+        You are acting as: <span className="text-indigo-600">Uploader </span>
+      </h2>
+      <h2 className="text-md font-semibold text-gray-800 dark:text-white mb-6">
+        For the file with CID :{" "}
+        <span className="text-indigo-600">
+          {result.cid.slice(0, 10)}...{result.cid.slice(-35)}
+        </span>
+      </h2>
+
+      <form onSubmit={handleSubmit} className="space-y-6">
+        <div className="relative">
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+            Number of Signers
+          </label>
+          <select
+            className="w-full px-4 py-2 border rounded-lg bg-gray-50 dark:bg-gray-800 text-gray-900 dark:text-white"
+            value={numSigners}
+            onChange={handleSignerCountChange}
+          >
+            {[1, 2, 3, 4, 5].map((num) => (
+              <option key={num} value={num}>
+                {num}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {signers.map((signer, idx) => (
+          <div
+            key={idx}
+            className="p-4 border rounded-lg space-y-4 bg-gray-50 dark:bg-gray-800"
+          >
+            <h3 className="text-md font-semibold text-gray-700 dark:text-white">
+              Signer {idx + 1}
+            </h3>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                Signer&rsquo;s DID
+              </label>
+              <input
+                type="text"
+                value={signer.did}
+                onChange={(e) => updateSignerField(idx, "did", e.target.value)}
+                placeholder="did:key:z..."
+                required
+                className="w-full px-4 py-2 border rounded-lg bg-white dark:bg-gray-900 text-gray-900 dark:text-white"
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                Capabilities (select multiple)
+              </label>
+              <div className="flex flex-wrap gap-2">
+                {baseCapabilities.map((cap) => (
+                  <label
+                    key={cap}
+                    className={`cursor-pointer px-3 py-1 rounded-full border ${
+                      signer.capabilities.includes(cap)
+                        ? "bg-indigo-600 text-white border-indigo-600"
+                        : "bg-white dark:bg-gray-900 text-gray-700 dark:text-gray-300 border-gray-300"
+                    }`}
+                  >
+                    <input
+                      type="checkbox"
+                      className="hidden"
+                      checked={signer.capabilities.includes(cap)}
+                      onChange={() => toggleCapability(idx, cap)}
+                    />
+                    {cap}
+                  </label>
+                ))}
+              </div>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                Access Deadline
+              </label>
+              <input
+                type="datetime-local"
+                value={signer.deadline}
+                onChange={(e) =>
+                  updateSignerField(idx, "deadline", e.target.value)
+                }
+                className="w-full px-4 py-2 border rounded-lg bg-white dark:bg-gray-900 text-gray-900 dark:text-white"
+                required
+              />
+            </div>
+          </div>
+        ))}
+
+        <button
+          type="submit"
+          className="w-full py-2 px-4 bg-indigo-600 hover:bg-indigo-700 text-white font-semibold rounded-lg shadow-md"
+        >
+          Generate Delegation
+        </button>
+      </form>
+    </div>
+  );
+};

--- a/docusign/src/types/types.ts
+++ b/docusign/src/types/types.ts
@@ -11,3 +11,10 @@ export interface PDFViewerProps {
   fileUrl?: string;
   height?: string;
 }
+
+
+export interface Signer{
+  did: string;
+  capabilities: string[];
+  deadline:string;
+};

--- a/docusign/src/utils/fileHelpers.ts
+++ b/docusign/src/utils/fileHelpers.ts
@@ -4,3 +4,6 @@ export function validateFile(file: File) {
     return { isValid: false, error: "Only PDF files are allowed." };
   return { isValid: true, error: null };
 }
+
+export const baseCapabilities = ['access/verify', 'upload/add'];
+// export const baseCapabilities = ['file/link', 'file/read'];


### PR DESCRIPTION
### Recent Updates to UCAN Delegation Flow

1. ✅ **Signer Selection UI**
   A component has been added to allow the issuer to dynamically select one or more signer DIDs.

2. ✅ **Capability Granting**
   Each signer is granted the `upload/get` capability based on their DID via UCAN delegation.

3. ✅ **UCAN Returned to Issuer**
   The delegation UCAN is returned to the issuer, allowing the recipients to invoke the granted capability.

4. ✅ **Local Storage Backup**
   All generated delegations are stored in the issuer's browser `localStorage`, so they can later be shared with the agent DIDs.

5. ✅ **PDF Upload of Delegations**
   The delegations are also converted into a `.pdf` file named `delegations-${result.cid}.pdf`, where `cid` is the content identifier of the original file. This file is uploaded to the storage space alongside the content.
