### PR TITLE
Add Demo Video to README for Docu-Sign on Storacha

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
-Docusign built on top of storacha to showcase UCAN capabilities.
+# Docu-Sign on Storacha
+
+## Docusign built on top of storacha to showcase UCAN capabilities.
+
+<p align="center">
+  <a href="https://youtu.be/AsviEgSqFhk">
+    <img src="https://img.youtube.com/vi/AsviEgSqFhk/0.jpg" alt="Demo Video" width="100%" />
+  </a>
+</p>
+

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 ## Docusign built on top of storacha to showcase UCAN capabilities.
 
+> Demo Video
+
 <p align="center">
   <a href="https://youtu.be/AsviEgSqFhk">
     <img src="https://img.youtube.com/vi/AsviEgSqFhk/0.jpg" alt="Demo Video" width="100%" />

--- a/README.md
+++ b/README.md
@@ -10,3 +10,5 @@
   </a>
 </p>
 
+## Blog on Implementation of IPNS + IPFS hybrid approach for tracking
+[Blog Link](https://medium.com/@gulshanpr/tracking-system-using-storacha-ucans-and-ipns-f4a7566dbad7)


### PR DESCRIPTION
This pull request updates the README.md to include a demo video showcasing Docu-Sign on Storacha, a Docusign-style application built on top of Storacha to demonstrate UCAN (User-Controlled Authorization Networks) capabilities.

Changes Made
1. Embedded a clickable YouTube thumbnail that links to the full demo video.
2. Ensured the video preview image is responsive and centered using inline HTML.